### PR TITLE
Add option to auto-expand the filetree at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ twf path/to/subdir/file
 
 ### Flags
 
+- `-autoexpandDepth <depth>`: Depth to which directories should be automatically expanded at startup. If `-1`, depth is unlimited. The default is `1`, meaning only the root should be expanded.
+- `-autoexpandIgnore <regexp>`: Regular expression matching relative paths to ignore when auto-expanding directories at startup.
+
+  For example, `^\.git|internal/filetree/testdata$` would ignore the `.git` directory at the root level as well as the `internal/filetree/testdata` directory.
+
 - `-bind <keybindings>`: Keybindings for command sequences.
 
   This takes the following format:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ twf path/to/subdir/file
 ### Flags
 
 - `-autoexpandDepth <depth>`: Depth to which directories should be automatically expanded at startup. If `-1`, depth is unlimited. The default is `1`, meaning only the root should be expanded.
-- `-autoexpandIgnore <regexp>`: Regular expression matching paths to ignore when auto-expanding directories at startup. The path that' tested against the regex is relative to the twf root and does not begin with `/` or `./`.
+- `-autoexpandIgnore <regexp>`: Regular expression matching paths to ignore when auto-expanding directories at startup. The path that's tested against the regex is relative to the twf root and does not begin with `/` or `./`.
 
   For example, `^(\.git|internal/filetree/testdata)$` would ignore the `.git` directory at the root level as well as the `internal/filetree/testdata` directory.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ twf path/to/subdir/file
 ### Flags
 
 - `-autoexpandDepth <depth>`: Depth to which directories should be automatically expanded at startup. If `-1`, depth is unlimited. The default is `1`, meaning only the root should be expanded.
-- `-autoexpandIgnore <regexp>`: Regular expression matching paths to ignore when auto-expanding directories at startup. The path that's tested against the regex is relative to the twf root and does not begin with `/` or `./`.
+- `-autoexpandIgnore <regexp>`: Regular expression matching paths to ignore when auto-expanding directories at startup. Each path tat's tested against the regex is relative to the twf root and does not begin with `/` or `./`, e.g. `foo/bar/qux`.
 
   For example, `^(\.git|internal/filetree/testdata)$` would ignore the `.git` directory at the root level as well as the `internal/filetree/testdata` directory.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ twf path/to/subdir/file
 ### Flags
 
 - `-autoexpandDepth <depth>`: Depth to which directories should be automatically expanded at startup. If `-1`, depth is unlimited. The default is `1`, meaning only the root should be expanded.
-- `-autoexpandIgnore <regexp>`: Regular expression matching paths to ignore when auto-expanding directories at startup. Each path tat's tested against the regex is relative to the twf root and does not begin with `/` or `./`, e.g. `foo/bar/qux`.
+- `-autoexpandIgnore <regexp>`: Regular expression matching paths to ignore when auto-expanding directories at startup. Each path that's tested against the regex is relative to the twf root and does not begin with `/` or `./`, e.g. `foo/bar/qux`.
 
   For example, `^(\.git|internal/filetree/testdata)$` would ignore the `.git` directory at the root level as well as the `internal/filetree/testdata` directory.
 

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ twf path/to/subdir/file
 ### Flags
 
 - `-autoexpandDepth <depth>`: Depth to which directories should be automatically expanded at startup. If `-1`, depth is unlimited. The default is `1`, meaning only the root should be expanded.
-- `-autoexpandIgnore <regexp>`: Regular expression matching relative paths to ignore when auto-expanding directories at startup.
+- `-autoexpandIgnore <regexp>`: Regular expression matching paths to ignore when auto-expanding directories at startup. The path that' tested against the regex is relative to the twf root and does not begin with `/` or `./`.
 
-  For example, `^\.git|internal/filetree/testdata$` would ignore the `.git` directory at the root level as well as the `internal/filetree/testdata` directory.
+  For example, `^(\.git|internal/filetree/testdata)$` would ignore the `.git` directory at the root level as well as the `internal/filetree/testdata` directory.
 
 - `-bind <keybindings>`: Keybindings for command sequences.
 

--- a/cmd/twf/main.go
+++ b/cmd/twf/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/wvanlint/twf/internal/config"
 	"github.com/wvanlint/twf/internal/filetree"
@@ -47,13 +48,20 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	err = tree.Expand()
-	if err != nil {
-		panic(err)
-	}
 	state := state.State{
 		Root:   tree,
 		Cursor: tree,
+	}
+
+	var ignore *regexp.Regexp
+	if config.AutoexpandIgnore != "" {
+		ignore, err = regexp.Compile(config.AutoexpandIgnore)
+		if err != nil {
+			panic(err)
+		}
+	}
+	if err := state.AutoExpand(config.AutoexpandDepth, ignore); err != nil {
+		panic(err)
 	}
 	if config.LocatePath != "" {
 		err = state.LocatePath(config.LocatePath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,14 +9,16 @@ import (
 )
 
 type TwfConfig struct {
-	LocatePath  string
-	LogLevel    string
-	Dir         string
-	Preview     PreviewConfig
-	TreeView    TreeViewConfig
-	Terminal    term.TerminalConfig
-	Graphics    GraphicsMapping
-	Keybindings Keybindings
+	LocatePath       string
+	LogLevel         string
+	Dir              string
+	Preview          PreviewConfig
+	TreeView         TreeViewConfig
+	Terminal         term.TerminalConfig
+	Graphics         GraphicsMapping
+	Keybindings      Keybindings
+	AutoexpandDepth  int
+	AutoexpandIgnore string
 }
 
 type PreviewConfig struct {
@@ -152,6 +154,18 @@ func GetConfig() *TwfConfig {
 		"preview",
 		true,
 		"Enable/disable previews.",
+	)
+	flag.IntVar(
+		&config.AutoexpandDepth,
+		"autoexpandDepth",
+		1,
+		"Depth to which directories should be automatically expanded at startup. -1 is unlimited.",
+	)
+	flag.StringVar(
+		&config.AutoexpandIgnore,
+		"autoexpandIgnore",
+		"",
+		"Regular expression matching relative paths to ignore when auto-expanding directories at startup.",
 	)
 	flag.StringVar(
 		&config.TreeView.LocateCommand,

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,6 +1,9 @@
 package state
 
 import (
+	"path/filepath"
+	"regexp"
+
 	"github.com/wvanlint/twf/internal/filetree"
 )
 
@@ -24,4 +27,30 @@ func (s *State) LocatePath(path string) error {
 		}
 	}
 	return nil
+}
+
+func (s *State) AutoExpand(maxDepth int, ignore *regexp.Regexp) error {
+	return s.Root.Traverse(false, nil, func(tree *filetree.FileTree, depth int) error {
+		if maxDepth >= 0 && depth >= maxDepth {
+			return nil
+		}
+		if tree == s.Root {
+			return tree.Expand()
+		}
+		parent := tree.Parent()
+		if parent != nil && !parent.Expanded() {
+			return nil
+		}
+
+		if ignore != nil {
+			rel, err := filepath.Rel(s.Root.AbsPath, tree.AbsPath)
+			if err != nil {
+				return err
+			}
+			if ignore.MatchString(rel) {
+				return nil
+			}
+		}
+		return tree.Expand()
+	})
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -30,7 +30,7 @@ func (s *State) LocatePath(path string) error {
 }
 
 func (s *State) AutoExpand(maxDepth int, ignore *regexp.Regexp) error {
-	return s.Root.Traverse(false, nil, func(tree *filetree.FileTree, depth int) error {
+	return s.Root.Traverse(true, nil, func(tree *filetree.FileTree, depth int) error {
 		if maxDepth >= 0 && depth >= maxDepth {
 			return nil
 		}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,61 @@
+package state
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wvanlint/twf/internal/filetree"
+)
+
+func TestAutoExpand(t *testing.T) {
+	for curDepth := -1; curDepth < 3; curDepth++ {
+		tree, err := filetree.InitFileTree("../filetree/testdata")
+		assert.Nil(t, err)
+		state := &State{Root: tree}
+		err = state.AutoExpand(curDepth, nil)
+		assert.Nil(t, err)
+		state.Root.Traverse(false, nil, func(node *filetree.FileTree, nodeDepth int) error {
+			if !node.IsDir() {
+				return nil
+			}
+			assert.Equal(t, curDepth == -1 || nodeDepth <= curDepth-1, node.Expanded())
+			return nil
+		})
+	}
+}
+
+func TestAutoExpandRegex(t *testing.T) {
+	re := regexp.MustCompile("dir1")
+	for curDepth := -1; curDepth < 3; curDepth++ {
+		tree, err := filetree.InitFileTree("../filetree/testdata")
+		assert.Nil(t, err)
+		state := &State{Root: tree}
+		err = state.AutoExpand(curDepth, re)
+		assert.Nil(t, err)
+		state.Root.Traverse(false, nil, func(node *filetree.FileTree, nodeDepth int) error {
+			if !node.IsDir() {
+				return nil
+			}
+			if node.Name() == "dir1" {
+				assert.False(t, node.Expanded())
+				return nil
+			}
+			assert.Equal(t, curDepth == -1 || nodeDepth <= curDepth-1, node.Expanded())
+			return nil
+		})
+	}
+
+	re = regexp.MustCompile(".*")
+	for curDepth := -1; curDepth < 3; curDepth++ {
+		tree, err := filetree.InitFileTree("../filetree/testdata")
+		assert.Nil(t, err)
+		state := &State{Root: tree}
+		err = state.AutoExpand(curDepth, re)
+		assert.Nil(t, err)
+		state.Root.Traverse(false, nil, func(node *filetree.FileTree, nodeDepth int) error {
+			assert.Equal(t, curDepth != 0 && nodeDepth == 0, node.Expanded())
+			return nil
+		})
+	}
+}


### PR DESCRIPTION
`-autoexpandDepth` controls the depth to which the file tree should be expanded initially:

- `-1`: all levels should be expanded
- `0`: no levels should be expanded
- `1`: (default) only the root node should be expanded, as in the hitherto default behavior.
- `>1`: this many levels should be expanded, indexed from 1 starting at the root

`-autoexpandIgnore` allows directories to be excluded from auto-expanding if they match a regular expression. The expression is tested against a directory's path relative to the root.